### PR TITLE
Master - Added CodeUpgrade

### DIFF
--- a/ITSMConfigurationManagement.sopm
+++ b/ITSMConfigurationManagement.sopm
@@ -1278,6 +1278,8 @@
 
         $Kernel::OM->Get($CodeModule)->CodeUpgradeFromLowerThan_4_0_8();
 
+        $Kernel::OM->Get($CodeModule)->CodeUpgradeFromLowerThan_4_0_91();
+
     ]]></CodeUpgrade>
     <CodeUpgrade Type="post"><![CDATA[
 


### PR DESCRIPTION
Hi @UdoBretz ,

Added CodeUpgrade function in packagesetup to change configurations to match the new module location.

Small confirmation from your side, if possible. Modules that used to be 'NavBarModuleAdmin' names are now 'NavBar::ModuleAdmin' are excluded from this PR. I assume that they will be placed in correct path by OTRS upgrade script or should they also be included here? If latter is the case i will update this PR accordingly. 

Thanks in advance for this info.

Regards
Sanjin
