### PR TITLE
Incident and Deployment state validation

### DIFF
--- a/Kernel/Modules/AgentITSMConfigItemEdit.pm
+++ b/Kernel/Modules/AgentITSMConfigItemEdit.pm
@@ -552,9 +552,8 @@ sub Run {
         Data         => $DeplStateList,
         Name         => 'DeplStateID',
         PossibleNone => 1,
-        Class        => 'Validate_Required' . $RowDeplStateInvalid,
+        Class        => 'Validate_Required Modernize' . $RowDeplStateInvalid,
         SelectedID   => $Version->{DeplStateID},
-        Class        => 'Modernize',
     );
 
     # output deployment state block
@@ -584,9 +583,8 @@ sub Run {
         Data         => $InciStateList,
         Name         => 'InciStateID',
         PossibleNone => 1,
-        Class        => 'Validate_Required' . $RowInciStateInvalid,
+        Class        => 'Validate_Required Modernize' . $RowInciStateInvalid,
         SelectedID   => $Version->{InciStateID},
-        Class        => 'Modernize',
     );
 
     # output incident state block


### PR DESCRIPTION
Fixed: Incident and Deployment state validation (required) wasn't working. When input fields were updated (modernized), there was already existing Class key in the hash and when developer added additional Class, it has overridden old value. The result: fields are not validated and server-side validation rejects form. However, after server validation fails, this fields are not marked as invalid, so the user has no idea what is wrong with data (i didn't fixed this issue).

If you need additional info, please contact me.