### PR TITLE
Add (optional) categories to ITSM overview

### DIFF
--- a/Kernel/Config/Files/ITSMConfigItem.xml
+++ b/Kernel/Config/Files/ITSMConfigItem.xml
@@ -826,5 +826,156 @@
             </Option>
         </Setting>
     </ConfigItem>
-
+    <ConfigItem Name="ITSM::Categories::Config###001" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Hardware</Item>
+                <Item Key="Prio">1000</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="DefaultFilter">23</Item>
+                <Item Key="CategoryID">001</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                        <Item>23</Item>
+                        <Item>24</Item>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###002" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Software</Item>
+                <Item Key="Prio">1010</Item>
+                <Item Key="ShowAllFilter">1</Item>
+                <Item Key="DefaultFilter">23</Item>
+                <Item Key="CategoryID">002</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                        <Item>23</Item>
+                        <Item>24</Item>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###003" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Network</Item>
+                <Item Key="Prio">1030</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="DefaultFilter">23</Item>
+                <Item Key="CategoryID">003</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                        <Item>23</Item>
+                        <Item>24</Item>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###004" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Generic Entry</Item>
+                <Item Key="Prio">1040</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="DefaultFilter">23</Item>
+                <Item Key="CategoryID">004</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                        <Item>23</Item>
+                        <Item>24</Item>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###005" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Generic Entry</Item>
+                <Item Key="Prio">1040</Item>
+                <Item Key="DefaultFilter">0</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="CategoryID">005</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###006" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Generic Entry</Item>
+                <Item Key="Prio">1060</Item>
+                <Item Key="DefaultFilter">0</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="CategoryID">006</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###007" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Generic Entry</Item>
+                <Item Key="Prio">1070</Item>
+                <Item Key="DefaultFilter">0</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="CategoryID">007</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="ITSM::Categories::Config###008" Required="0" Valid="0">
+        <Description Translatable="1">Defines the top level hierachy of categories which are shown in the CMDB overview.</Description>
+        <Group>ITSM Configuration Management</Group>
+        <SubGroup>Frontend::Agent::ITSMConfigItemOverview::Categories</SubGroup>
+        <Setting>
+            <Hash>
+                <Item Key="Name">Generic Entry</Item>
+                <Item Key="Prio">1080</Item>
+                <Item Key="DefaultFilter">0</Item>
+                <Item Key="ShowAllFilter">0</Item>
+                <Item Key="CategoryID">008</Item>
+                <Item Key="ContainedClassIDs">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Setting>
+    </ConfigItem>
 </otrs_config>

--- a/Kernel/Modules/AgentITSMConfigItem.pm
+++ b/Kernel/Modules/AgentITSMConfigItem.pm
@@ -326,29 +326,31 @@ sub Run {
         };
     }
 
-    # If we have active Categories and a filter, remove the not-contained
-    # class ids from the filter hash
+    # Iterate over filters and copy all those that are not restricted
+    my %NewNavBarFilter;
     if ($Categories && $Self->{Category} && $Self->{Category} ne 'All' ) {
+
         my $ContainedClassIDs = $Categories->{ $Self->{Category} }->{ContainedClassIDs};
         my $ShowAllFilter = $Categories->{ $Self->{Category} }->{ShowAllFilter};
 
         for my $ID (keys %NavBarFilter) {
             my $CurrentClassID = $NavBarFilter{$ID}->{Filter};
 
-            # Do not delete filters if:
-            # Filter id is contained in theclassids-array
-            # OR the ShowAllFilter is set to 1 AND the current filter is the all-filter
-	    unless (grep /^$CurrentClassID$/, @{ $ContainedClassIDs } ) {
-                unless ($ShowAllFilter eq 1 && $ID eq "1000") { 
-                    delete $NavBarFilter{$ID};
-                    # Rewrite ClassFilter if selected class is deleted:
-                    if ( $Self->{Filter} eq $CurrentClassID ) {
-                         $Self->{Filter} = $Categories->{ $Self->{Category} }->{DefaultFilter};
-                    }
+            if ( (grep /^$CurrentClassID$/, @{ $ContainedClassIDs })
+                  || ( $ShowAllFilter eq 1 && $ID eq "1000" ))
+                  {
+                    $NewNavBarFilter{$ID} = $NavBarFilter{$ID};
+            }
+            else {
+                # Rewrite ClassFilter if selected class is not copied:
+                if ( $Self->{Filter} eq $CurrentClassID ) {
+                     $Self->{Filter} = $Categories->{ $Self->{Category} }->{DefaultFilter};
                 }
             }
         }
+    %NavBarFilter = %NewNavBarFilter;
     }
+
     # show config item list
     $Output .= $LayoutObject->ITSMConfigItemListShow(
         ConfigItemIDs => $ConfigItemIDs,

--- a/Kernel/Output/HTML/Layout/ITSMConfigItem.pm
+++ b/Kernel/Output/HTML/Layout/ITSMConfigItem.pm
@@ -403,6 +403,54 @@ sub ITSMConfigItemListShow {
         );
     }
 
+    # Show Categories if active
+    if ( scalar keys $Param{Categories} > 0) {
+
+        # get given filters
+        my @NavBarCategoryFilters;
+        for my $Prio ( sort { $Param{Categories}->{$a}->{Prio} <=> $Param{Categories}->{$b}->{Prio} } keys %{ $Param{Categories} } ) {
+            push @NavBarCategoryFilters, $Param{Categories}->{$Prio};
+        }
+
+        # build category content
+        $LayoutObject->Block(
+            Name => 'OverviewNavBarCategory',
+        );
+
+        # loop over categories
+        CATEGORY:
+        for my $Category (@NavBarCategoryFilters) {
+
+            $LayoutObject->Block(
+                Name => 'OverviewNavBarCategoryItem',
+                Data => {
+                    %Param,
+                    %{$Category},
+                },
+            );
+
+            # category-filter is selected
+            if ( $Param{Category} && $Category->{CategoryID} eq $Param{Category} ) {
+                $LayoutObject->Block(
+                    Name => 'OverviewNavBarCategoryItemSelected',
+                    Data => {
+                        %Param,
+                        %{$Category},
+                    },
+                );
+            }
+            else {
+                $LayoutObject->Block(
+                    Name => 'OverviewNavBarCategoryItemSelectedNot',
+                    Data => {
+                        %Param,
+                        %{$Category},
+                    },
+                );
+            }
+        }
+    }
+
     # get filters
     if ( $Param{Filters} ) {
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMConfigItemOverviewNavBar.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMConfigItemOverviewNavBar.tt
@@ -13,6 +13,24 @@
 
     <div class="OverviewControl" id="OverviewControl">
         <div>
+[% RenderBlockStart("OverviewNavBarCategory") %]
+            <div class="ControlRow">
+                <ul class="Tabs">
+[% RenderBlockStart("OverviewNavBarCategoryItem") %]
+[% RenderBlockStart("OverviewNavBarCategoryItemSelected") %]
+                    <li class="Active [% Data.CSS | html %]">
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.FilterLink %]Filter=[% Data.Filter | uri %];Category=[% Data.CategoryID %]">[% Translate(Data.Name) | html %]<span>[% Data.Count | html %]</span></a>
+                    </li>
+[% RenderBlockEnd("OverviewNavBarCategoryItemSelected") %]
+[% RenderBlockStart("OverviewNavBarCategoryItemSelectedNot") %]
+                    <li class="[% Data.CSS | html %]">
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.FilterLink %]Filter=[% Data.Filter | uri %];Category=[% Data.CategoryID %]">[% Translate(Data.Name) | html %]<span>[% Data.Count | html %]</span></a>
+                    </li>
+[% RenderBlockEnd("OverviewNavBarCategoryItemSelectedNot") %]
+[% RenderBlockEnd("OverviewNavBarCategoryItem") %]
+                </ul>
+            </div>
+[% RenderBlockEnd("OverviewNavBarCategory") %]
             <div class="ControlRow">
 [% RenderBlockStart("OverviewNavBarFilter") %]
                 <ul class="Tabs">


### PR DESCRIPTION
When extensively using the CMDB, one might have too many class filters in the overview.

This change proposes an additional filterbar (called categories) above the ci-class filters. It can be configured in the sysconfig and fits with the layout.
