### PR TITLE
Add linked ConfigItems to ConfigItemGet

### DIFF
--- a/Kernel/GenericInterface/Operation/ConfigItem/ConfigItemGet.pm
+++ b/Kernel/GenericInterface/Operation/ConfigItem/ConfigItemGet.pm
@@ -212,6 +212,15 @@ sub Run {
             ConfigItemID => $ConfigItemID,
             UserID       => $UserID,
         );
+        
+        # get linked objects list
+        my $LinkListWithData = $Kernel::OM->Get('Kernel::System::LinkObject')->LinkListWithData(
+            Object           => 'ITSMConfigItem',
+            Object2          => 'ITSMConfigItem',
+            Key              => $ConfigItemID,
+            State            => 'Valid',
+            UserID           => $UserID,
+        );
 
         # get latest version
         my $Version = $ConfigItemObject->VersionGet(
@@ -289,6 +298,11 @@ sub Run {
             }
         }
 
+        # add list of linked objects to the bundle
+        if ($LinkListWithData) {
+             $ConfigItemBundle->{LinkListWithData} = $LinkListWithData;
+        }
+        
         # add
         push @Item, $ConfigItemBundle;
 


### PR DESCRIPTION
This is an enhancement to ConfigItemGet operation. Using this, the operation also returns a list of ConfigItems (LinkListWithData) that are related/linked to the ConfigItem you are getting.

This should also work for other objects, such as Tickets.
