### PR TITLE
Master - bug - AgentITSMConfigItemSearch order by Name

### DIFF
--- a/Kernel/System/ITSMConfigItem.pm
+++ b/Kernel/System/ITSMConfigItem.pm
@@ -1085,14 +1085,18 @@ sub ConfigItemSearch {
         CreateBy     => 'create_by',
         ChangeTime   => 'change_time',
         ChangeBy     => 'change_by',
+        Name         => 'civ.name',
     );
 
     # check if OrderBy contains only unique valid values
     my %OrderBySeen;
+    my $OrderByName;
     ORDERBY:
     for my $OrderBy ( @{ $Param{OrderBy} } ) {
 
-        next ORDERBY if $OrderBy eq 'Name';
+        if ( $OrderBy eq 'Name' ) {
+            $OrderByName = 1;
+        }
 
         if ( !$OrderBy || !$OrderByTable{$OrderBy} || $OrderBySeen{$OrderBy} ) {
 
@@ -1138,8 +1142,6 @@ sub ConfigItemSearch {
     my $Count = 0;
     ORDERBY:
     for my $OrderBy ( @{ $Param{OrderBy} } ) {
-
-        next ORDERBY if $OrderBy eq 'Name';
 
         # set the default order direction
         my $Direction = 'DESC';
@@ -1260,7 +1262,14 @@ sub ConfigItemSearch {
         $Param{Limit} = $Kernel::OM->Get('Kernel::System::DB')->Quote( $Param{Limit}, 'Integer' );
     }
 
-    my $SQL = "SELECT id FROM configitem $WhereString ";
+    my $SQL;
+    if ($OrderByName) {
+        $SQL
+            = "SELECT DISTINCT ci.id FROM configitem ci INNER JOIN configitem_version civ ON ci.id = civ.configitem_id $WhereString "
+    }
+    else {
+        $SQL = "SELECT id FROM configitem $WhereString ";
+    }
 
     # add the ORDER BY clause
     if (@SQLOrderBy) {


### PR DESCRIPTION
Hello @UdoBretz ,

Hereby is our proposal for fixing reporter issue in bug #12336

https://bugs.otrs.org/show_bug.cgi?id=12336

Although this bug is reported for OTRSCICustomerInterface there was same issue in AgentITSMConfigItemSearch where if you search by ConfigItem Number there was no possibility to sort by Name.

In ConfigItemSearch() function added SQL if search $Param{OrderBy} is Name to pull ID's from configitem table but sort them via joined table configitem_version where ConfigItem Name is saved. 

Updated Selenium tests where this type of behaviour is tested. We will create test also for OTRSCICustomerInterface with bug reproduction, although this fix will be necessary for solving reporters bug.

Please let me know if you have any questions regarding this bug fix proposal.

Regards,
Sanjin
