### PR TITLE
Marked strings as translatable

### DIFF
--- a/ITSMConfigurationManagement.sopm
+++ b/ITSMConfigurationManagement.sopm
@@ -265,7 +265,7 @@
         </TableCreate>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Class</Data>
-            <Data Key="name" Type="Quote">Computer</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Computer</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -274,7 +274,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Class</Data>
-            <Data Key="name" Type="Quote">Hardware</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Hardware</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -283,7 +283,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Class</Data>
-            <Data Key="name" Type="Quote">Location</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Location</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -292,7 +292,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Class</Data>
-            <Data Key="name" Type="Quote">Network</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Network</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -301,7 +301,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Class</Data>
-            <Data Key="name" Type="Quote">Software</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Software</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -310,7 +310,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Expired</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Expired</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -319,7 +319,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Inactive</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Inactive</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -328,7 +328,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Maintenance</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Maintenance</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -337,7 +337,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Pilot</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Pilot</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -346,7 +346,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Planned</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Planned</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -355,7 +355,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Production</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Production</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -364,7 +364,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Repair</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Repair</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -373,7 +373,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Retired</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Retired</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -382,7 +382,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Review</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Review</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -391,7 +391,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::DeploymentState</Data>
-            <Data Key="name" Type="Quote">Test/QA</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Test/QA</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -400,7 +400,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::YesNo</Data>
-            <Data Key="name" Type="Quote">Yes</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Yes</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -409,7 +409,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::YesNo</Data>
-            <Data Key="name" Type="Quote">No</Data>
+            <Data Key="name" Type="Quote" Translatable="1">No</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -418,7 +418,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Computer::Type</Data>
-            <Data Key="name" Type="Quote">Laptop</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Laptop</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -427,7 +427,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Computer::Type</Data>
-            <Data Key="name" Type="Quote">Desktop</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Desktop</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -436,7 +436,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Computer::Type</Data>
-            <Data Key="name" Type="Quote">Phone</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Phone</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -445,7 +445,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Computer::Type</Data>
-            <Data Key="name" Type="Quote">PDA</Data>
+            <Data Key="name" Type="Quote" Translatable="1">PDA</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -454,7 +454,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Computer::Type</Data>
-            <Data Key="name" Type="Quote">Server</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Server</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -463,7 +463,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Computer::Type</Data>
-            <Data Key="name" Type="Quote">Other</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Other</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -472,7 +472,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Monitor</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Monitor</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -481,7 +481,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Printer</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Printer</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -490,7 +490,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Switch</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Switch</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -499,7 +499,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Router</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Router</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -508,7 +508,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">WLAN Access Point</Data>
+            <Data Key="name" Type="Quote" Translatable="1">WLAN Access Point</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -517,7 +517,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Security Device</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Security Device</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -526,7 +526,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Backup Device</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Backup Device</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -535,7 +535,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Mouse</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Mouse</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -544,7 +544,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Keyboard</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Keyboard</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -553,7 +553,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Camera</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Camera</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -562,7 +562,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Beamer</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Beamer</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -571,7 +571,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Modem</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Modem</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -580,7 +580,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">PCMCIA Card</Data>
+            <Data Key="name" Type="Quote" Translatable="1">PCMCIA Card</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -589,7 +589,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">USB Device</Data>
+            <Data Key="name" Type="Quote" Translatable="1">USB Device</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -598,7 +598,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Docking Station</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Docking Station</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -607,7 +607,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Scanner</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Scanner</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -616,7 +616,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Hardware::Type</Data>
-            <Data Key="name" Type="Quote">Other</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Other</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -625,7 +625,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Building</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Building</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -634,7 +634,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Office</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Office</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -643,7 +643,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Floor</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Floor</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -652,7 +652,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Room</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Room</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -661,7 +661,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Rack</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Rack</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -670,7 +670,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Workplace</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Workplace</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -679,7 +679,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Outlet</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Outlet</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -688,7 +688,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">IT Facility</Data>
+            <Data Key="name" Type="Quote" Translatable="1">IT Facility</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -697,7 +697,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Location::Type</Data>
-            <Data Key="name" Type="Quote">Other</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Other</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -706,7 +706,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Network::Type</Data>
-            <Data Key="name" Type="Quote">LAN</Data>
+            <Data Key="name" Type="Quote" Translatable="1">LAN</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -715,7 +715,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Network::Type</Data>
-            <Data Key="name" Type="Quote">WLAN</Data>
+            <Data Key="name" Type="Quote" Translatable="1">WLAN</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -724,7 +724,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Network::Type</Data>
-            <Data Key="name" Type="Quote">Telco</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Telco</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -733,7 +733,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Network::Type</Data>
-            <Data Key="name" Type="Quote">GSM</Data>
+            <Data Key="name" Type="Quote" Translatable="1">GSM</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -742,7 +742,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Network::Type</Data>
-            <Data Key="name" Type="Quote">Other</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Other</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -751,7 +751,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Client Application</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Client Application</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -760,7 +760,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Middleware</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Middleware</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -769,7 +769,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Server Application</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Server Application</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -778,7 +778,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Client OS</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Client OS</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -787,7 +787,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Server OS</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Server OS</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -796,7 +796,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Admin Tool</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Admin Tool</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -805,7 +805,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">User Tool</Data>
+            <Data Key="name" Type="Quote" Translatable="1">User Tool</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -814,7 +814,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Embedded</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Embedded</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -823,7 +823,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::Type</Data>
-            <Data Key="name" Type="Quote">Other</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Other</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -832,7 +832,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Single Licence</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Single Licence</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -841,7 +841,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Per User</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Per User</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -850,7 +850,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Concurrent Users</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Concurrent Users</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -859,7 +859,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Per Processor</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Per Processor</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -868,7 +868,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Per Server</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Per Server</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -877,7 +877,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Per Node</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Per Node</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -886,7 +886,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Volume Licence</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Volume Licence</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -895,7 +895,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Enterprise Licence</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Enterprise Licence</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -904,7 +904,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Developer Licence</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Developer Licence</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -913,7 +913,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Demo</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Demo</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -922,7 +922,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Time Restricted</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Time Restricted</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -931,7 +931,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Freeware</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Freeware</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -940,7 +940,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Open Source</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Open Source</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -949,7 +949,7 @@
         </Insert>
         <Insert Table="general_catalog">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Software::LicenceType</Data>
-            <Data Key="name" Type="Quote">Unlimited</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Unlimited</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>
@@ -1098,7 +1098,7 @@
         </TableCreate>
         <Insert Table="general_catalog" Version="1.1.90">
             <Data Key="general_catalog_class" Type="Quote">ITSM::ConfigItem::Class</Data>
-            <Data Key="name" Type="Quote">Location</Data>
+            <Data Key="name" Type="Quote" Translatable="1">Location</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>
             <Data Key="create_by">1</Data>


### PR DESCRIPTION
Hi @UdoBretz 
Is it possible to mark strings as translatable in this way? If so, the [AAAITSMConfigItem.tt](https://github.com/OTRS/ITSMConfigurationManagement/blob/master/Kernel/Output/HTML/Templates/Standard/AAAITSMConfigItem.tt) file is no needed any more. 