### PR TITLE
Add Search Attribute

### DIFF
--- a/var/httpd/htdocs/js/ITSM.Agent.ConfigItem.Search.js
+++ b/var/httpd/htdocs/js/ITSM.Agent.ConfigItem.Search.js
@@ -191,6 +191,21 @@ ITSM.Agent.ConfigItem.Search = (function (TargetNS) {
             return false;
         });
 
+        // register add of attribute
+        $('#Attribute').bind('change', function () {
+            var Attribute = $('#Attribute').val();
+            TargetNS.SearchAttributeAdd(Attribute);
+            TargetNS.AdditionalAttributeSelectionRebuild();
+
+            // Register event for tree selection dialog
+            $('.ShowTreeSelection').unbind('click').bind('click', function () {
+                Core.UI.TreeSelection.ShowTreeSelection($(this));
+                return false;
+            });
+
+            return false;
+        });
+
         // register return key
         $('#SearchForm').unbind('keypress.FilterInput').bind('keypress.FilterInput', function (Event) {
             if ((Event.charCode || Event.keyCode) === 13) {


### PR DESCRIPTION
Currently if a search attribute need to be added, this attribute should be selected first and then the + button has to be clicked. This feature supports, if the search attribute is selected, it will be automatically added.