### PR TITLE
Marked class list as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardITSMConfigItemGeneric.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardITSMConfigItemGeneric.tt
@@ -13,12 +13,12 @@
 [% RenderBlockStart("OverviewNavBarFilterItem") %]
 [% RenderBlockStart("OverviewNavBarFilterItemSelected") %]
             <li class="Selected [% Data.CSS | html %] [% Data.Name | html %]">
-                <a href="#" id="DashboardAdditionalFilter[% Data.Name | html %]" data-filter="[% Data.Name | html %]" class="DashboardITSMConfigItemGenericFilter">[% Data.Name | html %] ([% Data.Count | html %]) </a>
+                <a href="#" id="DashboardAdditionalFilter[% Data.Name | html %]" data-filter="[% Data.Name | html %]" class="DashboardITSMConfigItemGenericFilter">[% Translate(Data.Name) | html %] ([% Data.Count | html %]) </a>
             </li>
 [% RenderBlockEnd("OverviewNavBarFilterItemSelected") %]
 [% RenderBlockStart("OverviewNavBarFilterItemSelectedNot") %]
             <li class="[% Data.CSS | html %] [% Data.Name | html %]">
-                <a href="#" id="DashboardAdditionalFilter[% Data.Name | html %]" data-filter="[% Data.Name | html %]" class="DashboardITSMConfigItemGenericFilter">[% Data.Name | html %] ([% Data.Count | html %]) </a>
+                <a href="#" id="DashboardAdditionalFilter[% Data.Name | html %]" data-filter="[% Data.Name | html %]" class="DashboardITSMConfigItemGenericFilter">[% Translate(Data.Name) | html %] ([% Data.Count | html %]) </a>
             </li>
 [% RenderBlockEnd("OverviewNavBarFilterItemSelectedNot") %]
 [% RenderBlockEnd("OverviewNavBarFilterItem") %]


### PR DESCRIPTION
Hi @UdoBretz 
The class list is already marked as translatable in the CMDB -> Overview screen, but in this screen they are displayed always in English. This PR makes it possible to translate this list, too.