### PR TITLE
Allow multiple links to customer company

### DIFF
--- a/Kernel/Output/HTML/Dashboard/ITSMConfigItemGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/ITSMConfigItemGeneric.pm
@@ -756,11 +756,12 @@ sub _AssignedCIsGet {
                 # Skip if we have no class id.
                 next CLASS if !$ClassID;
 
-                my @SearchKey = (
-                    {
-                        "[1]{'Version'}[1]{'$ConfigItemKey->{$Class}'}[%]{'Content'}" => $Self->{CustomerID},
-                    }
-                );
+                my @SearchKeys = split /,/, $ConfigItemKey->{$Class};
+                my $SearchParams = {};
+                foreach my $TargetKey (@SearchKeys) {
+                    $SearchParams->{"[1]{'Version'}[1]{'$TargetKey'}[%]{'Content'}"} = $Self->{CustomerID},
+                }
+                my @SearchKey = ($SearchParams);
 
                 # Perform config item search (extended).
                 my $ConfigItemIDs = $ConfigItemObject->ConfigItemSearchExtended(
@@ -793,11 +794,12 @@ sub _AssignedCIsGet {
                 # Skip if we have no class id.
                 next CLASS if !$ClassID;
 
-                my @SearchKey = (
-                    {
-                        "[1]{'Version'}[1]{'$ConfigItemKey->{$Class}'}[%]{'Content'}" => $Self->{CustomerUserID},
-                    }
-                );
+                my @SearchKeys = split /,/, $ConfigItemKey->{$Class};
+                my $SearchParams = {};
+                foreach my $TargetKey (@SearchKeys) {
+                    $SearchParams->{"[1]{'Version'}[1]{'$TargetKey'}[%]{'Content'}"} = $Self->{CustomerUserID},
+                }
+                my @SearchKey = ($SearchParams);
 
                 # Perform config item search (extended).
                 my $ConfigItemIDs = $ConfigItemObject->ConfigItemSearchExtended(


### PR DESCRIPTION
For the use case that you have multiple fields in a CI of the type CustomerCompany, it would be helpful to allow multiple keys in the config.

E.g.
ConfigItem "Server" has a field Owner of type CustomerCompany with key CustomerID
and
Provider of type CustomerCompany with key ProviderID

Then we could put into this sysconfig item:
0060-CIC-ITSMConfigItemCustomerCompany
a comma separated list of keys to be checked:
Server => "CustomerID,PartnerID"